### PR TITLE
Added return to trunk_drop

### DIFF
--- a/mf.conf
+++ b/mf.conf
@@ -90,19 +90,17 @@ exten => s,1,Progress
 exten => 22,1,Dial(IAX2/npstn@scpa01.ddns.net/5312600)
 	same => n,Hangup
 
-
-
 [trunk_drop]
 exten => s,1,NoOp(TRUNK RESET)
 	same => n,System(/usr/sbin/asterisk -rx "confbridge kick ${UNIQUEID} all")
         same => n,System(rm -rf /tmp/${UNIQUEID}-st.wav)
         same => n,System(rm -rf /tmp/${UNIQUEID}-full.wav)
+	same => n,Return()
 	
 [trunk_access]
 exten => _X.,1,Answer ; ANSWER internal trunk
 	same => n,Confbridge(${EXTEN},mf_bridge,mf_user)
 	same => n,Hangup
-
 
 [mfrecv_full]
 exten => _X.,1,Answer ; ANSWER internal trunk


### PR DESCRIPTION
Added Return to trunk_drop, as hangup handlers are subroutines. This fixes a runtime error.